### PR TITLE
Infrastructure improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Wagtail’s CircleCI continuous integration [triggers publication of nightly rel
 
 ## Infrastructure
 
-`releases.wagtail.org` (and the legacy `releases.wagtail.io`) is hosted in an S3 bucket (named `releases.wagtail.io`). ACLs are used to mark files as public.
+`releases.wagtail.org` (and the legacy `releases.wagtail.io`) is hosted in an S3 bucket (named `releases.wagtail.io`). The entire bucket is considered public.
 
-For additional security and performance, CloudFront is used to globally cache requests. CloudFront handles TLS termination, HTTPS redirects, compression and caching.
+For additional security and performance, CloudFront is used to globally cache requests. CloudFront handles TLS termination, HTTPS redirects, compression and caching. CloudFront uses signed URLs (Origin Access Control) to access the bucket, to prevent access to the bucket directly.
 
 ## Deploying changes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Wagtail’s [latest.txt](https://github.com/wagtail/wagtail/blob/main/scripts/la
 
 Wagtail’s CircleCI continuous integration [triggers publication of nightly releases](https://github.com/wagtail/wagtail/blob/main/.circleci/trigger-nightly-build.sh). Those releases are shared on the [nightly releases index](https://releases.wagtail.org/nightly/index.html).
 
+## Infrastructure
+
+`releases.wagtail.org` (and the legacy `releases.wagtail.io`) is hosted in an S3 bucket (named `releases.wagtail.io`). ACLs are used to mark files as public.
+
+For additional security and performance, CloudFront is used to globally cache requests. CloudFront handles TLS termination, HTTPS redirects, compression and caching.
+
 ## Deploying changes
 
 To deploy changes in this repository, run the `deploy.py` script using `uv`:

--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ Wagtail’s [latest.txt](https://github.com/wagtail/wagtail/blob/main/scripts/la
 ## Nightly releases
 
 Wagtail’s CircleCI continuous integration [triggers publication of nightly releases](https://github.com/wagtail/wagtail/blob/main/.circleci/trigger-nightly-build.sh). Those releases are shared on the [nightly releases index](https://releases.wagtail.org/nightly/index.html).
+
+## Deploying changes
+
+To deploy changes in this repository, run the `deploy.py` script using `uv`:
+
+```
+uv run deploy.py
+```
+
+You must have access to the relevant S3 bucket (`releases.wagtail.io`).
+
+`deploy.py` will upload the files, and then clear the cache. The cache is cleared in the background, so may take a couple minutes for the changes to propagate.

--- a/deploy.py
+++ b/deploy.py
@@ -7,6 +7,7 @@
 from pathlib import Path
 import uuid
 import boto3
+import mimetypes
 
 BUCKET = "releases.wagtail.io"
 CLOUDFRONT_DISTRIBUTION_ID = "E283SZ5CB4MDM0"
@@ -23,12 +24,15 @@ def main():
 
     for file in publish_files:
         path = "nightly/" + str(file.relative_to(PUBLISH_DIR))
+
+        mime_type, _encoding = mimetypes.guess_type(file)
+
         print("Uploading", path)
         s3_client.upload_file(
             str(file),
             BUCKET,
             path,
-            ExtraArgs={"ACL": "public-read"},
+            ExtraArgs={"ACL": "public-read", "ContentType": mime_type},
         )
         uploaded_paths.append(path)
 

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,49 @@
+# /// script
+# dependencies = [
+#   "boto3"
+# ]
+# ///
+
+from pathlib import Path
+import uuid
+import boto3
+
+BUCKET = "releases.wagtail.io"
+CLOUDFRONT_DISTRIBUTION_ID = "E283SZ5CB4MDM0"
+
+PUBLISH_DIR = Path(__file__).parent / "nightly"
+
+
+def main():
+    s3_client = boto3.client("s3")
+
+    publish_files = list(PUBLISH_DIR.rglob("*.*"))
+
+    uploaded_paths = []
+
+    for file in publish_files:
+        path = "nightly/" + str(file.relative_to(PUBLISH_DIR))
+        print("Uploading", path)
+        s3_client.upload_file(
+            str(file),
+            BUCKET,
+            path,
+            ExtraArgs={"ACL": "public-read"},
+        )
+        uploaded_paths.append(path)
+
+    print("Clearing cache")
+    boto3.client("cloudfront").create_invalidation(
+        DistributionId=CLOUDFRONT_DISTRIBUTION_ID,
+        InvalidationBatch={
+            "Paths": {
+                "Quantity": len(publish_files),
+                "Items": [f"/{path}" for path in uploaded_paths],
+            },
+            "CallerReference": str(uuid.uuid4()),
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR has a go at improving the `releases.wagtail.org` infrastructure:

- Add a `deploy.py` script (which has been tested) to deploy the `nightly/` directory to S3
- Briefly document the infrastructure setup

The infrastructure isn't especially complex, and doesn't change enough to warrant deployment through CI or Terraforming. If the need arises, it can be handled in future.